### PR TITLE
Fix Logging::Rails::Mixin to work on Ruby < 1.9

### DIFF
--- a/lib/logging/rails/mixin.rb
+++ b/lib/logging/rails/mixin.rb
@@ -16,7 +16,8 @@ module Logging::Rails
     # extend the including class so it also has a class-level `logger` method.
     #
     def self.included( other )
-      other.__send__(:remove_method, :logger) if other.instance_methods.include? :logger
+      logger_method = RUBY_VERSION < '1.9' ? 'logger' : :logger
+      other.__send__(:remove_method, :logger) if other.instance_methods.include? logger_method
       other.extend self
     end
 
@@ -25,8 +26,9 @@ module Logging::Rails
     # version.
     #
     def self.extended( other )
+      logger_method = RUBY_VERSION < '1.9' ? 'logger' : :logger
       eigenclass = class << other; self; end
-      eigenclass.__send__(:remove_method, :logger) if eigenclass.instance_methods.include? :logger
+      eigenclass.__send__(:remove_method, :logger) if eigenclass.instance_methods.include? logger_method
     end
 
     # Returns the logger instance.


### PR DESCRIPTION
Module#instance_methods returns an array of strings in Ruby < 1.9 and an
array of symbols in >= 1.9
