### PR TITLE
Switched logging gem dependency from ~> 1.6.1 to >= 1.6.1 to allow usage of newer logging gem versions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-
 begin
   require 'bones'
 rescue LoadError
@@ -15,6 +14,6 @@ Bones {
 
   use_gmail
 
-  depend_on 'logging', '~> 1.6.1'
+  depend_on 'logging', '>= 1.6.1'
 }
 


### PR DESCRIPTION
Hi Tim,

Please merge these changes into the main branch.

Thanks,
- Michael
