### PR TITLE
removed global logger method

### DIFF
--- a/lib/logging/rails.rb
+++ b/lib/logging/rails.rb
@@ -1,6 +1,5 @@
 
 require 'logging'
-include Logging.globally
 
 require 'rails' if !defined? Rails or Rails.version
 


### PR DESCRIPTION
This fixes issue #10. I think it's easier to just use the mixin wherever a logger is needed.. 
