### PR TITLE
Adding compatibility for Rails 5

### DIFF
--- a/lib/logging/rails/railtie.rb
+++ b/lib/logging/rails/railtie.rb
@@ -35,8 +35,10 @@ module Logging::Rails
       ActiveSupport.on_load(:action_mailer) { self.__send__(:include, ::Logging::Rails::Mixin) }
     end
 
-    initializer 'logging.active_support.dependencies.logger' do
-      ActiveSupport::Dependencies.logger = ::Logging::Logger[ActiveSupport::Dependencies]
+    if ActiveSupport::Dependencies.respond_to? :logger= then
+      initializer 'logging.active_support.dependencies.logger' do
+        ActiveSupport::Dependencies.logger = ::Logging::Logger[ActiveSupport::Dependencies]
+      end
     end
 
     initializer 'logging.initialize_cache', :after => 'initialize_cache' do


### PR DESCRIPTION
Rails removed logging from ActiveSupport::Dependencies in
https://github.com/rails/rails/commit/798dc5a92537ba4202a1a8e127a5ebdae87bc78d

Fixes #22