### PR TITLE
Replace deprecated call to File.exists?

### DIFF
--- a/lib/logging/rails/railtie.rb
+++ b/lib/logging/rails/railtie.rb
@@ -15,7 +15,7 @@ module Logging::Rails
 
     initializer 'logging.configure', :before => 'initialize_logger' do |app|
       file = ::Rails.root.join('config/logging.rb')
-      load file if File.exists? file
+      load file if File.exist? file
       ::Logging::Rails.configuration.call(app.config) if ::Logging::Rails.configuration
     end
 


### PR DESCRIPTION
`File.exists?` is deprecated in favor of `File.exist?`. This change is required for compatibility with Ruby 3.2