### PR TITLE
Fix File.exists?

### DIFF
--- a/lib/logging/rails/railtie.rb
+++ b/lib/logging/rails/railtie.rb
@@ -15,7 +15,7 @@ module Logging::Rails
 
     initializer 'logging.configure', :before => 'initialize_logger' do |app|
       file = ::Rails.root.join('config/logging.rb')
-      load file if File.exists? file
+      load file if File.exist? file
       ::Logging::Rails.configuration.call(app.config) if ::Logging::Rails.configuration
     end
 


### PR DESCRIPTION
File.exists? must be replaced by File.exist? on ruby 3.2.0.